### PR TITLE
add client and builder functionality

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// Client represents a client configuration (with or without TLS).
+type Client struct {
+
+	// Host defines the hostname or address of the client.
+	Host string `json:"host" mapstructure:"host" yaml:"host"`
+
+	// Port defines the port for the client.
+	Port int `json:"port" mapstructure:"port" yaml:"port"`
+
+	// TLS defines the TLS configuration for the client.
+	TLS Configuration `json:"tls" mapstructure:"tls" yaml:"tls"`
+}
+
+// Build creates an http.Client from a Client.
+func (c *Client) Build() (*http.Client, error) {
+
+	configuration, err := c.TLS.Build()
+	if err != nil {
+		return nil, errors.Wrap(err, "error building tls configuration for client")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialTLS: func(network, address string) (net.Conn, error) {
+				return tls.Dial("tcp", fmt.Sprintf("%s:%d", c.Host, c.Port), configuration)
+			},
+		},
+	}
+
+	return client, nil
+}
+
+// WithHost sets the hostname or address of the client.
+func (c *Client) WithHost(host string) *Client {
+	c.Host = host
+	return c
+}
+
+// WithPort sets the port of the client.
+func (c *Client) WithPort(port int) *Client {
+	c.Port = port
+	return c
+}
+
+// WithTLS sets the TLS configuration of the client.
+func (c *Client) WithTLS(tls Configuration) *Client {
+	c.TLS = tls
+	return c
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/deciphernow/nautls/internal/tests"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestClient(t *testing.T) {
+
+	Convey("When Client", t, func() {
+
+		client := &Client{}
+
+		Convey(".WithHost is invoked", func() {
+
+			host := tests.MustGenerateString(t)
+
+			client.WithHost(host)
+
+			Convey("it sets the host", func() {
+				So(client.Host, ShouldEqual, host)
+			})
+		})
+
+		Convey(".WithPort is invoked", func() {
+
+			port := tests.MustGenerateInt(t)
+
+			client.WithPort(port)
+
+			Convey("it sets the port", func() {
+				So(client.Port, ShouldEqual, port)
+			})
+		})
+
+		Convey(".WithTLS is invoked", func() {
+
+			tls := tests.MustGenerate(reflect.TypeOf(Configuration{}), t).Interface().(Configuration)
+
+			client.WithTLS(tls)
+
+			Convey("it sets the tls", func() {
+				So(client.TLS, ShouldResemble, tls)
+			})
+		})
+
+		Convey(".Build is invoked", func() {
+
+			http, err := client.Build()
+
+			Convey("it returns a nil error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("it returns the client", func() {
+				So(http, ShouldNotBeZeroValue)
+			})
+		})
+	})
+}

--- a/client/configuration.go
+++ b/client/configuration.go
@@ -58,3 +58,27 @@ func (c *Configuration) Build() (*tls.Config, error) {
 
 	return config, nil
 }
+
+// WithAuthority sets the trusted certificate authority.
+func (c *Configuration) WithAuthority(authority string) *Configuration {
+	c.Authorities = []string{authority}
+	return c
+}
+
+// WithCertificate sets the client certificate used for mTLS connections.
+func (c *Configuration) WithCertificate(certificate string) *Configuration {
+	c.Certificate = certificate
+	return c
+}
+
+// WithKey sets the client key used for mTLS connections.
+func (c *Configuration) WithKey(key string) *Configuration {
+	c.Key = key
+	return c
+}
+
+// WithServer sets the server name used for verification.
+func (c *Configuration) WithServer(server string) *Configuration {
+	c.Server = server
+	return c
+}

--- a/client/configuration_test.go
+++ b/client/configuration_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/deciphernow/nautls/internal/tests"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestConfiguration(t *testing.T) {
+
+	Convey("When Configuration", t, func() {
+
+		configuration := &Configuration{}
+
+		Convey(".Build is invoked", func() {
+
+			tls, err := configuration.Build()
+
+			Convey("it returns a nil error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("it returns the configuration", func() {
+				So(tls, ShouldNotBeZeroValue)
+			})
+		})
+
+		Convey(".WithAuthority is invoked", func() {
+
+			authority := tests.MustGenerateString(t)
+			authorities := []string{authority}
+
+			configuration.WithAuthority(authority)
+
+			Convey("it sets the authority", func() {
+				So(configuration.Authorities, ShouldResemble, authorities)
+			})
+		})
+
+		Convey(".WithCertificate is invoked", func() {
+
+			certificate := tests.MustGenerateString(t)
+
+			configuration.WithCertificate(certificate)
+
+			Convey("it sets the certificate", func() {
+				So(configuration.Certificate, ShouldEqual, certificate)
+			})
+		})
+
+		Convey(".WithKey is invoked", func() {
+
+			key := tests.MustGenerateString(t)
+
+			configuration.WithKey(key)
+
+			Convey("it sets the key", func() {
+				So(configuration.Key, ShouldEqual, key)
+			})
+		})
+
+		Convey(".WithServer is invoked", func() {
+
+			server := tests.MustGenerateString(t)
+
+			configuration.WithServer(server)
+
+			Convey("it sets the server", func() {
+				So(configuration.Server, ShouldEqual, server)
+			})
+		})
+	})
+}


### PR DESCRIPTION
@dborncamp, so with this pull request you should be able to create a client with:

```
httpClient, err := (&client.Client{}).
	WithHost("www.google.com").
	WithPort(443).
	WithTLS(*(&client.Configuration{}).
		WithAuthority("file:///etc/tls/ca.crt").
		WithCertificate("file:///etc/tls/certificate.crt").
		WithKey("file:///etc/tls/key.crt").
		WithServer("google.com")).
	Build()
```
It is ugly and suggests at some refactoring but it should work.