### PR TITLE
fix identity issuance self signing errors

### DIFF
--- a/identities/identity.go
+++ b/identities/identity.go
@@ -62,12 +62,12 @@ func (i *Identity) Issue(template Template) (*Identity, error) {
 		return nil, errors.Wrapf(err, "error generating private key for [%s]", template.Subject.CommonName)
 	}
 
-	certificate, err := sign(template.certificate(), template.certificate(), &key.PublicKey, key)
+	certificate, err := sign(template.certificate(), i.Certificate, &key.PublicKey, i.Key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error signing certificate for [%s]", template.Subject.CommonName)
 	}
 
-	return NewIdentity(append(i.Authorities, i.Certificate), certificate, key), nil
+	return NewIdentity(append([]*x509.Certificate{i.Certificate}, i.Authorities...), certificate, key), nil
 }
 
 // sign returns a signed certificate for the provided template.


### PR DESCRIPTION
See #21 for an explanation.

At this point the easiest way to test this is to actually build `acert` with this as a dependency and issue certificates.  

1. Checkout this branch of acert: https://github.com/DecipherNow/acert/tree/nautls
1. Build: `make build`
1. Create an authority: `export AUTHORITY=$(./bin/acert authorities create -n EXAMPLE)`
1. Create a leaf: `export LEAF=$(./bin/acert authorities issue ${AUTHORITY} -n ELPMAXE)`
1. Export the key: `./bin/acert leaves export ${LEAF} -t key > elpmaxe.key`
1. Export the certificate: `./bin/acert leaves export ${LEAF} -t certificate > elpmaxe.crt`
1. Export the ca: `./bin/acert leaves export ${LEAF} -t authority > elpmaxe.ca.crt`
1. Verify the certificate: `openssl verify -CAfile elpmaxe.ca.crt elpmaxe.crt`

